### PR TITLE
Feature/task7 9

### DIFF
--- a/src/main/java/jp/seekengine/trainingjava/controller/Schedule.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/Schedule.java
@@ -1,0 +1,36 @@
+package jp.seekengine.trainingjava.controller;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "schedule")
+public class Schedule {
+
+    // ゲッター & セッター
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String fromDatetime;  // 独自の日時フォーマットで保存
+    private String toDatetime;    // 独自の日時フォーマットで保存
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setFromDatetime(String fromDatetime) {
+        this.fromDatetime = fromDatetime;
+    }
+
+    public void setToDatetime(String toDatetime) {
+        this.toDatetime = toDatetime;
+    }
+
+    // 必要であれば、他のメソッドやコンストラクタも追加できます
+}

--- a/src/main/java/jp/seekengine/trainingjava/controller/ScheduleController.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import jp.seekengine.trainingjava.domain.ScheduleService;
 import jp.seekengine.trainingjava.infrastructure.entity.MessageEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -13,7 +14,9 @@ import java.time.Duration;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 public class ScheduleController {
@@ -211,4 +214,16 @@ public class ScheduleController {
         return scheduleService.searchMessage(message);
     }
 
+
+    @PostMapping("/schedule")
+    public ResponseEntity<Map<String, Long>> createSchedule(@RequestBody ScheduleRequest request) {
+        Long scheduleId = scheduleService.createSchedule(request.title(), request.fromDatetime(), request.toDatetime());
+        Map<String, Long> response = Collections.singletonMap("schedule_id", scheduleId);
+        return ResponseEntity.ok(response);
+    }
+    @GetMapping("/schedule/{id}")
+    public ResponseEntity<ScheduleResponse> responesSchedule(@PathVariable Long id) {
+        ScheduleResponse response = scheduleService.getScheduleById(id);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/jp/seekengine/trainingjava/controller/ScheduleController.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/ScheduleController.java
@@ -221,9 +221,18 @@ public class ScheduleController {
         Map<String, Long> response = Collections.singletonMap("schedule_id", scheduleId);
         return ResponseEntity.ok(response);
     }
+
     @GetMapping("/schedule/{id}")
     public ResponseEntity<ScheduleResponse> responesSchedule(@PathVariable Long id) {
         ScheduleResponse response = scheduleService.getScheduleById(id);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/schedule/range")
+    public ResponseEntity<List<ScheduleItemResponse>> getSchedulesByTimeRange(
+            @RequestParam String fromDatetime,
+            @RequestParam String toDatetime) {
+        List<ScheduleItemResponse> schedules = scheduleService.getSchedulesByTimeRange(fromDatetime, toDatetime);
+        return ResponseEntity.ok(schedules);
     }
 }

--- a/src/main/java/jp/seekengine/trainingjava/controller/ScheduleRepository.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/ScheduleRepository.java
@@ -1,9 +1,14 @@
 package jp.seekengine.trainingjava.controller;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import jp.seekengine.trainingjava.controller.Schedule;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    @Query("SELECT s FROM Schedule s WHERE s.fromDatetime > :fromDatetime AND s.toDatetime < :toDatetime")
+    List<Schedule> findSchedulesByTimeRange(@Param("fromDatetime") String fromDatetime, @Param("toDatetime") String toDatetime);
 }
 

--- a/src/main/java/jp/seekengine/trainingjava/controller/ScheduleRepository.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/ScheduleRepository.java
@@ -1,0 +1,9 @@
+package jp.seekengine.trainingjava.controller;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import jp.seekengine.trainingjava.controller.Schedule;
+
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}
+

--- a/src/main/java/jp/seekengine/trainingjava/controller/request/ScheduleRequest.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/request/ScheduleRequest.java
@@ -1,0 +1,7 @@
+package jp.seekengine.trainingjava.controller.request;
+
+import java.io.Serializable;
+
+public record ScheduleRequest(
+        String title, String fromDatetime, String toDatetime
+)implements Serializable {}

--- a/src/main/java/jp/seekengine/trainingjava/controller/response/ScheduleItemResponse.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/response/ScheduleItemResponse.java
@@ -1,0 +1,8 @@
+package jp.seekengine.trainingjava.controller.response;
+
+import java.io.Serializable;
+
+public record ScheduleItemResponse(
+        Long id, String title, String fromDatetime, String toDatetime
+) implements Serializable {
+}

--- a/src/main/java/jp/seekengine/trainingjava/controller/response/ScheduleResponse.java
+++ b/src/main/java/jp/seekengine/trainingjava/controller/response/ScheduleResponse.java
@@ -1,0 +1,7 @@
+package jp.seekengine.trainingjava.controller.response;
+
+import java.io.Serializable;
+
+public record ScheduleResponse(
+        Long id, String title, String fromDatetime, String toDatetime
+)implements Serializable {}

--- a/src/main/java/jp/seekengine/trainingjava/domain/ScheduleService.java
+++ b/src/main/java/jp/seekengine/trainingjava/domain/ScheduleService.java
@@ -1,23 +1,19 @@
 package jp.seekengine.trainingjava.domain;
 
-import jp.seekengine.trainingjava.controller.request.SampleTimeRequest;
-import jp.seekengine.trainingjava.controller.response.SampleTimeResponse;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
+import jakarta.persistence.EntityNotFoundException;
+import jp.seekengine.trainingjava.controller.Schedule;
+import jp.seekengine.trainingjava.controller.ScheduleRepository;
+import jp.seekengine.trainingjava.controller.response.ScheduleResponse;
 import jp.seekengine.trainingjava.infrastructure.SampleRepository;
 import jp.seekengine.trainingjava.infrastructure.entity.MessageEntity;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Service
 public class ScheduleService {
@@ -70,8 +66,26 @@ public class ScheduleService {
         return sampleRepository.findByMessageContaining(message);
     }
 
+    @Autowired
+    private ScheduleRepository scheduleRepository;
 
+    public Long createSchedule(String title, String fromDatetime, String toDatetime) {
+        Schedule schedule = new Schedule();
+        schedule.setTitle(title);
+        schedule.setFromDatetime(fromDatetime);
+        schedule.setToDatetime(toDatetime);
+        scheduleRepository.save(schedule);
+        return schedule.getId();
+    }
+
+    public ScheduleResponse getScheduleById(Long id) {
+        Schedule schedule = scheduleRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + id));
+
+        return new ScheduleResponse(schedule.getId(), schedule.getTitle(), schedule.getFromDatetime(), schedule.getToDatetime());
+    }
 }
+
 
 
 

--- a/src/main/java/jp/seekengine/trainingjava/domain/ScheduleService.java
+++ b/src/main/java/jp/seekengine/trainingjava/domain/ScheduleService.java
@@ -3,6 +3,7 @@ package jp.seekengine.trainingjava.domain;
 import jakarta.persistence.EntityNotFoundException;
 import jp.seekengine.trainingjava.controller.Schedule;
 import jp.seekengine.trainingjava.controller.ScheduleRepository;
+import jp.seekengine.trainingjava.controller.response.ScheduleItemResponse;
 import jp.seekengine.trainingjava.controller.response.ScheduleResponse;
 import jp.seekengine.trainingjava.infrastructure.SampleRepository;
 import jp.seekengine.trainingjava.infrastructure.entity.MessageEntity;
@@ -14,6 +15,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ScheduleService {
@@ -83,6 +85,13 @@ public class ScheduleService {
                 .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + id));
 
         return new ScheduleResponse(schedule.getId(), schedule.getTitle(), schedule.getFromDatetime(), schedule.getToDatetime());
+    }
+
+    public List<ScheduleItemResponse> getSchedulesByTimeRange(String fromDatetime, String toDatetime) {
+        List<Schedule> schedules = (List<Schedule>) scheduleRepository.findSchedulesByTimeRange(fromDatetime, toDatetime);
+        return schedules.stream()
+                .map(schedule -> new ScheduleItemResponse(schedule.getId(), schedule.getTitle(), schedule.getFromDatetime(), schedule.getToDatetime()))
+                .collect(Collectors.toList());
     }
 }
 


### PR DESCRIPTION
# やったこと
## Task7
スケジュールをDB登録するAPI
## Task8
スケジュールIDを指定してDBからスケジュールを取得するAPI
## Task9
開始時刻と終了時刻を指定してDBからスケジュールのリストを取得するA
PI
# 動作確認
ローカルで確認済み
## task7動作確認
指定した時刻を登録してその際のIDを返却すること
![スクリーンショット 2023-10-30 150655](https://github.com/y-takahashi-seek/training-202310/assets/147672259/63b306ab-8e97-4133-9ffe-fc0c20667929)
## task8動作確認
IDを入れた際にID番号と時刻・タイトルを返却する
![スクリーンショット 2023-10-30 152638](https://github.com/y-takahashi-seek/training-202310/assets/147672259/6b9048fd-453f-4525-bf11-b8336a03d7d6)
## task9動作確認
DBに登録されている時刻・IDをリスト化してすべて返却させること
![スクリーンショット 2023-10-30 162040](https://github.com/y-takahashi-seek/training-202310/assets/147672259/489996ad-f5b2-49bf-8d3b-cbc0500be598)


# レビュアーの申し送り事項
漢字へ変更時に警告のようなが時々確認されます。
(例UFT8)
Task7のエラーは引き続き確認できますが使用には問題ありません